### PR TITLE
Update footer copyright year to be dynamic

### DIFF
--- a/home.html
+++ b/home.html
@@ -365,7 +365,7 @@
                 </div>
             </div>
         </div>
-        <p class="copyright">Copyright &copy; 2024 CSEdge.<br>All Rights Reserved Designed By Team CSEdge</p>
+        <p class="copyright">Copyright &copy; <script>document.write(new Date().getFullYear())</script> CSEdge.<br>All Rights Reserved Designed By Team CSEdge</p>
     </footer>
 
 

--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
     <footer class="py-5 bg-dark">
       <div class="container">
         <p class="m-0 text-center text-white">
-          Copyright &copy CSEdge Learn 2024
+          Copyright &copy CSEdge Learn <script>document.write(new Date().getFullYear())</script>
         </p>
       </div>
     </footer>


### PR DESCRIPTION
Fixed issue #112 

This pull request updates the footer copyright year to be dynamically generated using JavaScript. The current year is now displayed automatically, ensuring that the year is always up-to-date without manual intervention. This improves the user experience by reflecting the current year in the copyright notice.
