### PR TITLE
Fixed the Footer Links under "About CSEdge" and "Learn More" section! #290

### DIFF
--- a/home.html
+++ b/home.html
@@ -372,7 +372,7 @@
                 <h4>About CSEdge</h4>
                 <p>CSEdge is an online internship platform that provides students with the opportunity to gain practical
                     experience in the field of software development.</p>
-                <a style="text-decoration: none;" class="btn" href="../index.html#about">Read More</a>
+                <a style="text-decoration: none;" class="btn" href="csedge.courses/about.html">Read More</a>
             </div>
             <div class="footer-links">
                 <h4>Need Help?</h4>
@@ -392,8 +392,8 @@
                 <ul>
                     <li><a href="#home">Home</a></li>
                     <li><a href="#internship">Internships</a></li>
-                    <li><a href="#about">About Us</a></li>
-                    <li><a href="#services">Services</a></li>
+                    <li><a href="#AboutUS">About Us</a></li>
+                    <li><a href="index.html#Services">Services</a></li>
                     <li><a href="#faq">FAQ</a></li>
                     <li><a href="./verify-id.html">Verify Certificate</a></li>
                 </ul>


### PR DESCRIPTION
## Description
The footer tabs under the "About CSEdge" ("_Read More_" button) and "_About_" and "_Services_" tabs under the "learn More" section are now correctly navigating to their respective files.

## Issue Number:
Fixed issue number: #290 

## Screenshot:
Below is the screen short of "_Read More_" tab correctly navigating to its respective file


![image](https://github.com/CSEdgeOfficial/learn.csedge.courses/assets/169380578/d7b83eb9-3411-43bf-a81c-ac7e14a59c21)
![image](https://github.com/CSEdgeOfficial/learn.csedge.courses/assets/169380578/ddb365a4-ae7f-45e9-b9f3-fbd04690ff12)

